### PR TITLE
Add standardTargetOptions to build.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,7 +1,12 @@
 const Builder = @import("std").build.Builder;
 
 pub fn build(b: *Builder) void {
+    const target = b.standardTargetOptions(.{});
     const mode = b.standardReleaseOptions();
+
+    if (!target.isLinux()) {
+        @panic("Currently, only Linux is supported as the target OS");
+    }
 
     const logind = b.option(
         bool,
@@ -19,6 +24,7 @@ pub fn build(b: *Builder) void {
         exe.linkSystemLibrary("libsystemd");
     }
 
+    exe.setTarget(target);
     exe.setBuildMode(mode);
     exe.install();
 


### PR DESCRIPTION
This option is included in all new projects created by `zig init-exe` or `zig init-lib` by default and allows building for a target that is different from the native target (different CPU, different ABI in this case as Linux is the only OS currently supported afaik).