### PR TITLE
Change .mode to specific mode

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -246,7 +246,7 @@ fn printString(msg: []const u8) !void {
 }
 
 fn writeFile(path: []const u8, value: u32) !void {
-    var file = fs.cwd().openFile(path, .{ .mode = .write_only }) catch |err| {
+    var file = fs.cwd().openFile(path, .{ .read = false, .write = true } ) catch |err| {
         std.debug.print("Cannot open {s} with write permissions.\n", .{path});
         return err;
     };


### PR DESCRIPTION
Compiling on commit 680f61f results in error:

```
./src/main.zig:249:43: error: no member named 'mode' in struct 'std.fs.file.OpenFlags'
    var file = fs.cwd().openFile(path, .{ .mode = .write_only }) catch |err| {
                                          ^
brightnessztl...The following command exited with error code 1:
/usr/x86_64-pc-linux-musl/bin/zig build-exe /home/archmux/Internet/Git/Display/Brightness/brightnessztl/src/main.zig --cache-dir /home/archmux/Internet/Git/Display/Brightness/brightnessztl/zig-cache --global-cache-dir /home/archmux/.cache/zig --name brightnessztl --pkg-begin build_options /home/archmux/Internet/Git/Display/Brightness/brightnessztl/zig-cache/options/8zCT-3OHX8UR588nMnl2sDLUFCNtT9v4TvsSevLIz86KwWxoZ96zMC9z4KHE_w9O --pkg-end --enable-cache
error: the following build command failed with exit code 1:
/home/archmux/Internet/Git/Display/Brightness/brightnessztl/zig-cache/o/b8ca359ac713685833de433bd663ae10/build /usr/x86_64-pc-linux-musl/bin/zig /home/archmux/Internet/Git/Display/Brightness/brightnessztl /home/archmux/Internet/Git/Display/Brightness/brightnessztl/zig-cache /home/archmux/.cache/zig -Dlogind=false

```

Original behavior of `write_only` is preserved.