### PR TITLE
Update to latest zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -29,10 +29,13 @@ pub fn build(b: *Builder) void {
         exe.linkSystemLibrary("libsystemd");
     }
 
-    exe.install();
+    b.installArtifact(exe);
 
-    const run_cmd = exe.run();
+    const run_cmd = b.addRunArtifact(exe);
     run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
 
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);


### PR DESCRIPTION
Updates to zig version 0.11.0-dev.2862+66da64d77

@hspak Once zig 0.11.0 is released, would it make sense to track the stable version of zig in the `master` branch and have a different (e.g. `0.12.x` branch) for tracking the zig master branch?